### PR TITLE
Adjust API URLs

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -39,7 +39,7 @@ module.exports = {
     };
 
     // Query Art Insititue of Chicago API and return response
-    return fetch('https://aggregator-data.artic.edu/api/v1/search', {
+    return fetch('https://api.artic.edu/api/v1/search', {
       method: 'POST',
       body: JSON.stringify(artworkRequest),
       headers: { 'Content-Type': 'application/json' }

--- a/server.js
+++ b/server.js
@@ -65,9 +65,9 @@ app.post('/sms', (req, res) => {
         const response = twiml.message();
         console.log('got object, building message', data);
         const image =
-          'https://lakeimagesweb.artic.edu/iiif/2/' +
+          'https://www.artic.edu/iiif/2/' +
           data.image_id +
-          '/full/1000,/0/default.jpg';
+          '/full/843,/0/default.jpg';
 
         response.body(
           `Title: ${data.title}\n\nArtist: ${data.artist_display}\n\nDate: ${data.date_display}\n\nMedium: ${data.medium_display}\nwww.artic.edu/artworks/${data.id}`


### PR DESCRIPTION
Thanks again for sharing your project with us! It's nice to see what people make with our API.

As mentioned, I have some suggestions. Just sharing some institutional knowledge:

 - https://api.artic.edu is the new-ish canonical URL for the AIC API. We need to update our docs!

 - Retrieving IIIF images through `www` instead of the `lakeimagesweb` subdomain makes the request go through AIC's CDN, instead of hitting our [Cantaloupe](https://cantaloupe-project.github.io/) image server directly. By going through the CDN, you greatly increase the chance that a cache collision will happen. If the image you are requesting happens to be cached in the CDN, your request will process much faster. Our image server also contains some internal caches, but they are generally short-lived. Thinking in terms of scale, we encourage people to use the CDN to reduce load on our image server.

 - Changed the image derivative size parameter from `1000,` to `843,`. In conjunction with the IIIF subdomain change suggested above, this change will help increase the chances of a cache collision happening: `843,` is the size AIC uses on all artwork detail pages. Additionally, our website limits the width of non-public domain images to `843,`, and this change abides by that convention.

We'll try to add these to our documentation when we find the time!